### PR TITLE
Set data-app in custom Vuetify mount command

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,6 +32,8 @@ Cypress.Commands.add("mount", (MountedComponent, options) => {
   if (!root.classList.contains("v-application")) {
     root.classList.add("v-application");
   }
+  // Vuetify selector used for popup elements to attach to the DOM
+  root.setAttribute('data-app', 'true');
 
   return mount(MountedComponent, {
     vuetify,


### PR DESCRIPTION
Default Vuetify behavior in certain components (like v-menu, v-autocomplete) is to attach a popup to an ancestor with a `data-app` attribute, the same element that has the `v-application` class. I added the suggested change to my command and am able to successfully test a component that uses a v-autocomplete, so I thought it might be handy in this repo.